### PR TITLE
Add Phync_Logger_FileDiffLogger

### DIFF
--- a/src/Phync/Application.php
+++ b/src/Phync/Application.php
@@ -15,6 +15,7 @@ require_once dirname(__FILE__) . '/Console/Colorizer.php';
 require_once dirname(__FILE__) . '/Event/Dispatcher.php';
 require_once dirname(__FILE__) . '/Event/Event.php';
 require_once dirname(__FILE__) . '/Logger/NamedTextLogger.php';
+require_once dirname(__FILE__) . '/Logger/FileDiffLogger.php';
 require_once dirname(__FILE__) . '/CommandGenerator.php';
 require_once dirname(__FILE__) . '/RsyncExecuter.php';
 require_once dirname(__FILE__) . '/Exception/ConfigNotFound.php';
@@ -71,6 +72,7 @@ class Phync_Application
         $this->colorizer  = new Phync_Console_Colorizer;
 
         $this->dispatcher->addObserver(new Phync_Logger_NamedTextLogger);
+        $this->dispatcher->addObserver(new Phync_Logger_FileDiffLogger);
 
         $this->dispatcher->on('after_config_loading', array($this, 'displayConfigFilePath'));
         $this->dispatcher->on('after_config_loading', array($this, 'validateFiles'));
@@ -253,6 +255,11 @@ __USAGE__;
     public function getOption()
     {
         return $this->option;
+    }
+
+    public function getConfig()
+    {
+        return $this->config;
     }
 
     public function getEvent()

--- a/src/Phync/FileUtil.php
+++ b/src/Phync/FileUtil.php
@@ -42,11 +42,6 @@ class Phync_FileUtil
         return is_link($path);
     }
 
-    public function isBinary($path)
-    {
-        return (preg_match('#\0#', file_get_contents($path)) === 1);
-    }
-
     public function shellescape($arg)
     {
         return escapeshellarg($arg);

--- a/src/Phync/FileUtil.php
+++ b/src/Phync/FileUtil.php
@@ -42,6 +42,11 @@ class Phync_FileUtil
         return is_link($path);
     }
 
+    public function isBinary($path)
+    {
+        return (preg_match('#\0#', file_get_contents($path)) === 1);
+    }
+
     public function shellescape($arg)
     {
         return escapeshellarg($arg);

--- a/src/Phync/Logger/AbstractLogger.php
+++ b/src/Phync/Logger/AbstractLogger.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * This file is part of Phync.
+ *
+ * (c) Yuya Takeyama
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+abstract class Phync_Logger_AbstractLogger
+{
+    /**
+     * @var resource
+     */
+    protected $log;
+    protected static $name;
+
+    public function openLogFile(Phync_Event_Event $event, $name)
+    {
+        $file  = $event->app->getLogDirectory() . DIRECTORY_SEPARATOR .
+            date('Ymd') . '-' . $name . '.log';
+        $log = @fopen($file, 'a');
+        if ($log === false) {
+            throw new RuntimeException("Failed to open log file: \"{$file}\"");
+        }
+
+        return $log;
+    }
+
+    public function write($messages)
+    {
+        $messages = func_get_args();
+        $text = date('Y-m-d H:i:s');
+        foreach ($messages as $message) {
+            $text .= "\t" . $message;
+        }
+        $text .= PHP_EOL;
+        fputs($this->log, $text);
+    }
+
+    public function __destruct()
+    {
+        if (is_resource($this->log)) {
+            fclose($this->log);
+        }
+    }
+}

--- a/src/Phync/Logger/FileDiffLogger.php
+++ b/src/Phync/Logger/FileDiffLogger.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * This file is part of Phync.
+ *
+ * (c) Yuya Takeyama
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require_once dirname(__FILE__) . '/../Event/ObserverInterface.php';
+require_once dirname(__FILE__) . '/../Event/Event.php';
+require_once dirname(__FILE__) . '/../FileUtil.php';
+
+class Phync_Logger_FileDiffLogger extends Phync_Logger_AbstractLogger implements Phync_Event_ObserverInterface
+{
+    /**
+     * @var string
+     */
+    private $diff;
+
+    public function update(Phync_Event_Event $event)
+    {
+        switch ($event->getName()) {
+            case 'after_config_loading':
+                if (!self::$name) $this->getName();
+                $this->log = $this->openLogFile($event, self::$name);
+                break;
+            case 'before_command_execution':
+                $fileUtil = new Phync_FileUtil;
+                $this->onBeforeCommandExecution($event, $fileUtil);
+                break;
+            default:
+                break;
+        }
+    }
+
+    public function onBeforeCommandExecution(Phync_Event_Event $event, Phync_FileUtil $fileUtil)
+    {
+        $config = $event->app->getConfig();
+        $files = $this->getFileList($event, $config, $fileUtil);
+
+        list($destinationHost) = $config->getDestinations();
+        $workingDir = $fileUtil->getCwd();
+        $rsh = $config->getRsh();
+
+        foreach ($files as $fileOrDir) {
+            $targetPath = $workingDir . DIRECTORY_SEPARATOR . $fileOrDir;
+            $this->getFileDiff($targetPath, $rsh, $destinationHost, $fileUtil);
+        }
+
+        $this->write('[DIFF]', PHP_EOL . $this->diff);
+    }
+
+    /**
+     * ファイル一覧を取得
+     * exclude_from 設定を反映した結果を取得するために dry-run 結果からファイル名を抽出する
+     * 
+     * @param   Phync_Event_Event
+     * @param   Phync_Config
+     * @param   Phync_FileUtil
+     * @return  array
+     * @access  public
+     */
+    public function getFileList( Phync_Event_Event $event, Phync_Config $config, Phync_FileUtil $fileUtil)
+    {
+        $option = clone $event->app->getOption();
+        $option->setDryRun();
+        $commandGenerator = new Phync_CommandGenerator($config, $fileUtil);
+        list($command) = $commandGenerator->getCommands($option);
+        $message = `{$command}`;
+
+        return $this->extractFileList($message, $fileUtil);
+    }
+
+    /**
+     * dry-run 結果出力からファイル名を抽出
+     *
+     * @param   string
+     * @return  array
+     * @access  public
+     */
+    public function extractFileList($message)
+    {
+        $files = array();
+        foreach (explode("\n", $message) as $line) {
+            // ディレクトリ
+            if (empty($line) || $line === './') continue;
+            if (substr($line, -1, 1) === '/') continue;
+            // ヘッダ、フッタ行
+            if (substr($line, 0, 18) === 'building file list' || substr($line, 0, 5) === 'sent ' || substr($line, 0, 10) === 'total size') continue;
+            // シンボリックリンク
+            if (strpos($line, ' -> ') !== false) {
+                $pos = strpos($line, ' -> ');
+                $files[] = substr($line, 0, $pos);
+                continue;
+            }
+            $files[] = $line;
+        }
+
+        return $files;
+    }
+
+    public function getFileDiff($targetPath, $rsh, $destinationHost, Phync_FileUtil $fileUtil)
+    {
+        if ($fileUtil->isLink($targetPath)) {
+            $this->diff .= "{$targetPath} is link." . PHP_EOL;
+            return;
+        } elseif ($fileUtil->isDir($targetPath)) {
+            foreach(new DirectoryIterator($targetPath) as $fileOrDir) {
+                $this->getFileDiff($fileOrDir->getPathname(), $rsh, $destinationHost, $fileUtil);
+            }
+        } elseif ($fileUtil->isBinary($targetPath)) {
+            $this->diff .= "{$targetPath} is binary." . PHP_EOL;
+            return;
+        } elseif ($fileUtil->isFile($targetPath)) {
+            $this->diff .= $targetPath . PHP_EOL;
+            $this->diff .= `{$rsh} {$destinationHost} cat {$targetPath} 2> /dev/null | diff - {$targetPath}`;
+            $this->diff .= PHP_EOL;
+        }
+    }
+}

--- a/src/Phync/Logger/FileDiffLogger.php
+++ b/src/Phync/Logger/FileDiffLogger.php
@@ -23,7 +23,9 @@ class Phync_Logger_FileDiffLogger extends Phync_Logger_AbstractLogger implements
     {
         switch ($event->getName()) {
             case 'after_config_loading':
-                if (!self::$name) $this->getName();
+                if (!self::$name) {
+                    $this->getName();
+                }
                 $this->log = $this->openLogFile($event, self::$name);
                 break;
             case 'before_command_execution':
@@ -85,10 +87,16 @@ class Phync_Logger_FileDiffLogger extends Phync_Logger_AbstractLogger implements
         $files = array();
         foreach (explode("\n", $message) as $line) {
             // ディレクトリ
-            if (empty($line) || $line === './') continue;
-            if (substr($line, -1, 1) === '/') continue;
+            if (empty($line) || $line === './') {
+                continue;
+            }
+            if (substr($line, -1, 1) === '/') {
+                continue;
+            }
             // ヘッダ、フッタ行
-            if (substr($line, 0, 18) === 'building file list' || substr($line, 0, 5) === 'sent ' || substr($line, 0, 10) === 'total size') continue;
+            if (substr($line, 0, 18) === 'building file list' || substr($line, 0, 5) === 'sent ' || substr($line, 0, 10) === 'total size') {
+                continue;
+            }
             // シンボリックリンク
             if (strpos($line, ' -> ') !== false) {
                 $pos = strpos($line, ' -> ');

--- a/src/Phync/Logger/FileDiffLogger.php
+++ b/src/Phync/Logger/FileDiffLogger.php
@@ -113,18 +113,16 @@ class Phync_Logger_FileDiffLogger extends Phync_Logger_AbstractLogger implements
     {
         if ($fileUtil->isLink($targetPath)) {
             $this->diff .= "{$targetPath} is link." . PHP_EOL;
-            return;
         } elseif ($fileUtil->isDir($targetPath)) {
             foreach(new DirectoryIterator($targetPath) as $fileOrDir) {
                 $this->getFileDiff($fileOrDir->getPathname(), $rsh, $destinationHost, $fileUtil);
             }
-        } elseif ($fileUtil->isBinary($targetPath)) {
-            $this->diff .= "{$targetPath} is binary." . PHP_EOL;
-            return;
         } elseif ($fileUtil->isFile($targetPath)) {
             $this->diff .= $targetPath . PHP_EOL;
             $this->diff .= `{$rsh} {$destinationHost} cat {$targetPath} 2> /dev/null | diff - {$targetPath}`;
             $this->diff .= PHP_EOL;
         }
+
+        return;
     }
 }

--- a/src/Phync/Logger/NamedTextLogger.php
+++ b/src/Phync/Logger/NamedTextLogger.php
@@ -10,24 +10,16 @@
 
 require_once dirname(__FILE__) . '/../Event/ObserverInterface.php';
 require_once dirname(__FILE__) . '/../Event/Event.php';
+require_once dirname(__FILE__) . '/AbstractLogger.php';
 
-class Phync_Logger_NamedTextLogger implements Phync_Event_ObserverInterface
+class Phync_Logger_NamedTextLogger extends Phync_Logger_AbstractLogger implements Phync_Event_ObserverInterface
 {
-    private $name;
-
-    private $log;
-
     public function update(Phync_Event_Event $event)
     {
         switch ($event->getName()) {
         case 'after_config_loading':
-            $this->name = $this->getName();
-            $file  = $event->app->getLogDirectory() . DIRECTORY_SEPARATOR .
-                date('Ymd') . '-' . $this->name . '.log';
-            $this->log = @fopen($file, 'a');
-            if ($this->log === false) {
-                throw new RuntimeException("Failed to open log file: \"{$file}\"");
-            }
+            if (!self::$name) $this->getName();
+            $this->log = $this->openLogFile($event, self::$name);
             break;
         case 'before_command_execution':
             $this->onBeforeCommandExecution($event);
@@ -38,30 +30,20 @@ class Phync_Logger_NamedTextLogger implements Phync_Event_ObserverInterface
         }
     }
 
-    public function getName()
+    public function getName($input = STDIN)
     {
         echo "Your name: ";
         while (true) {
-            $name = fgets(STDIN);
+            $name = fgets($input);
             if (is_string($name)) {
                 $name = chop(preg_replace('/\.+/u', '.', $name));
                 if ($name !== '') {
-                    return $name;
+                    self::$name = $name;
+                    return;
                 }
             }
             echo "Invalid input.", PHP_EOL;
         }
-    }
-
-    public function write($messages)
-    {
-        $messages = func_get_args();
-        $text = date('Y-m-d H:i:s');
-        foreach ($messages as $message) {
-            $text .= "\t" . $message;
-        }
-        $text .= PHP_EOL;
-        fputs($this->log, $text);
     }
 
     public function onBeforeCommandExecution(Phync_Event_Event $event)
@@ -72,12 +54,5 @@ class Phync_Logger_NamedTextLogger implements Phync_Event_ObserverInterface
     public function onAfterCommandExecution(Phync_Event_Event $event)
     {
         $this->write('[STATUS]', (string)$event->status);
-    }
-
-    public function __destruct()
-    {
-        if (is_resource($this->log)) {
-            fclose($this->log);
-        }
     }
 }

--- a/src/Phync/Option.php
+++ b/src/Phync/Option.php
@@ -80,6 +80,11 @@ class Phync_Option
         $this->dryRun = ((bool)$pred) === false;
     }
 
+    public function setDryRun()
+    {
+        $this->dryRun = true;
+    }
+
     /**
      * ドライランで実行するか.
      *

--- a/tests/Phync/Tests/Logger/FileDiffLoggerTest.php
+++ b/tests/Phync/Tests/Logger/FileDiffLoggerTest.php
@@ -44,6 +44,7 @@ __EOS__;
             'phynctest/hello.php',
             'phynctest/test.txt',
             'phynctest/ticket01.gif',
+            'phynctest/directory/hello.link.php',
             'phynctest/directory/test.txt',
         );
         $this->assertSame($expect, $this->logger->extractFileList($message));

--- a/tests/Phync/Tests/Logger/FileDiffLoggerTest.php
+++ b/tests/Phync/Tests/Logger/FileDiffLoggerTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of Phync.
+ *
+ * (c) Yuya Takeyama
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require_once 'Phync/Logger/FileDiffLogger.php';
+
+class Phync_Tests_Logger_FileDiffLoggerTest extends Phync_Tests_TestCase
+{
+    public function setUp()
+    {
+        $this->logger = new Phync_Logger_FileDiffLogger;
+    }
+
+    /**
+     * @test
+     */
+    public function extractFileList_dryrun結果出力からファイル一覧のみを抽出()
+    {
+        $message = <<<__EOS__
+building file list ... done
+./
+hello.php
+phynctest/
+phynctest/hello.php
+phynctest/test.txt
+phynctest/ticket01.gif
+phynctest/directory/
+phynctest/directory/hello.link.php -> hello.php
+phynctest/directory/directory2/
+phynctest/directory/test.txt
+
+sent 548 bytes  received 80 bytes  1256.00 bytes/sec
+total size is 8461  speedup is 13.47
+__EOS__;
+
+        $expect = array(
+            'hello.php',
+            'phynctest/hello.php',
+            'phynctest/test.txt',
+            'phynctest/ticket01.gif',
+            'phynctest/directory/test.txt',
+        );
+        $this->assertSame($expect, $this->logger->extractFileList($message));
+    }
+}

--- a/tests/Phync/Tests/Logger/NamedTextLoggerTest.php
+++ b/tests/Phync/Tests/Logger/NamedTextLoggerTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * This file is part of Phync.
+ *
+ * (c) Yuya Takeyama
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require_once 'Phync/Logger/NamedTextLogger.php';
+
+class Phync_Tests_Logger_NamedTextLoggerTest extends Phync_Tests_TestCase
+{
+    public function setUp()
+    {
+        $this->logger = new Phync_Logger_NamedTextLogger;
+    }
+
+    /**
+     * @test
+     */
+    public function openLogFile_対象ログファイルリソースを返す()
+    {
+        $fileUtil = Phake::partialMock('Phync_FileUtil');
+        $app   = Phake::partialMock('Phync_Application', array(
+            'env'       => array(),
+            'option'    => new Phync_Option(array()),
+            'config'    => new Phync_Config(array('destinations' => array('localhost'))),
+            'file_util' => $fileUtil,
+        ));
+        Phake::when($app)
+            ->getLogDirectory()
+            ->thenReturn(dirname(__FILE__) . '/log/');
+        $event = Phake::partialMock('Phync_Event_Event', array('app' => $app));
+
+        $this->assertTrue(is_resource($this->logger->openLogFile($event, 'anyone')));
+    }
+
+    /**
+     * @test
+     * @expectedException RuntimeException
+     */
+    public function openLogFile_ファイルを開けなければRuntimeExceptionを投げる()
+    {
+        $fileUtil = Phake::partialMock('Phync_FileUtil');
+        $app   = Phake::partialMock('Phync_Application', array(
+            'env'       => array(),
+            'option'    => new Phync_Option(array()),
+            'config'    => new Phync_Config(array('destinations' => array('localhost'))),
+            'file_util' => $fileUtil,
+        ));
+        Phake::when($app)
+            ->getLogDirectory()
+            ->thenReturn('invalid_directory');
+        $event = Phake::partialMock('Phync_Event_Event', array('app' => $app));
+        $this->logger->openLogFile($event, 'anyone');
+    }
+
+    /**
+     * @test
+     */
+    public function write_引数に渡した文字列をlogリソースに書き込む()
+    {
+        $fileUtil = Phake::partialMock('Phync_FileUtil');
+        $app   = Phake::partialMock('Phync_Application', array(
+            'env'       => array(),
+            'option'    => new Phync_Option(array()),
+            'config'    => new Phync_Config(array('destinations' => array('localhost'))),
+            'file_util' => $fileUtil,
+        ));
+        Phake::when($app)
+            ->getLogDirectory()
+            ->thenReturn(dirname(__FILE__) . '/log/');
+
+        $event = Phake::partialMock('Phync_Event_Event', array('app' => $app));
+        Phake::when($event)
+            ->getName()
+            ->thenReturn('after_config_loading');
+
+        // NamedTextLogger::getNameの入力リソースを差し替える
+        $name = 'anyone';
+        $fp = fopen('php://temp', 'r+');
+        fputs($fp, $name);
+        rewind($fp);
+        $this->logger->getName($fp);
+        fclose($fp);
+
+        $logfile = dirname(__FILE__) . '/log/' . date('Ymd') . "-{$name}.log";
+        unlink($logfile);
+
+        $this->logger->update($event);
+        $message = 'test message';
+        $this->logger->write($message);
+        $expect = date('Y-m-d H:i:s') . "\t{$message}" . PHP_EOL;
+        $result = file_get_contents($logfile);
+
+        $this->assertSame($expect, $result);
+    }
+}


### PR DESCRIPTION
Added the observer to leave the log file diff.
Along with that,
- created an abstract class to put together a common process with the NamedTextLogger.
- added a test of Logger.

Example of log entry with the Phync_Logger_FileDiffLogger.

```
$ phync sample.php phynctest/
```

```
2014-02-03 23:35:43 [DIFF]
/Users/Ack/Develop/sample.php
13,15c13,15
< if (function_exists('apc_clear_cache')) {
<     if (version_compare(phpversion('apc'), '4.0.0') < 0) {
<         apc_clear_cache('user');

---
> if (!function_exists('apc_clear_cache')) {
>     if (version_compare(phpversion('apc'), '5.0.0') < 0) {
>         apc_clear_cache('users');

/Users/Ack/Develop/phynctest/application.php
38,40d37
<         // for backward-compatible (new command "install")
<         $this->registerCommand( 'bundle' , 'Onion\Command\InstallCommand' );
<         $this->registerCommand( 'self-update' );

/Users/Ack/Develop/phynctest/sample.link is link.
/Users/Ack/Develop/phynctest/ticket01.gif is binary.
```
