### PR TITLE
Disable FileDiffLogger temporary

### DIFF
--- a/src/Phync/Application.php
+++ b/src/Phync/Application.php
@@ -59,7 +59,6 @@ class Phync_Application
         $this->colorizer  = new Phync_Console_Colorizer;
 
         $this->dispatcher->addObserver(new Phync_Logger_NamedTextLogger);
-        $this->dispatcher->addObserver(new Phync_Logger_FileDiffLogger);
 
         $this->dispatcher->on('after_config_loading', array($this, 'displayConfigFilePath'));
         $this->dispatcher->on('after_config_loading', array($this, 'validateFiles'));


### PR DESCRIPTION
@ackintosh
`FileDiffLogger` is cool, but it takes so long time.

So I want to disable this feature temporary.

IMHO, enabling `FileDiffLogger` requires below.
- Configuration to disable/enable `FileDiffLogger`
- Command-line option to disable/enable `FileDiffLogger`
