### PR TITLE
Add remote_target_directory config

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ return array(
 -------------------|------------------------------------------------------------------------------------------------|----|-----------------------------------------------------|
 destinations       |シンク先サーバのホスト名を配列で指定する。                                                      |Yes |`array('server1.example.net', 'server2.example.net')`|
 ssh\_user          |対象ホストへの接続に使用する SSH ユーザ名。                                                     |No  |`'testuser'`                                         |
-remote\_target\_dir|リモートの対象ディレクトリへのパス。                                                            |No  |`'/path/to/target-directory'`                        |
+remote\_target\_dir|リモートの対象ディレクトリへのパス。デフォルトではローカルのカレントと同じパスが対象となる。    |No  |`'/path/to/target-directory'`                        |
 exclude\_from      |`rsync` コマンドの `--exclude-from` オプション。除外ファイルの一覧を記述したファイルを指定する。|No  |`dirname(__FILE__) . '/rsync_exclude'`               |
 rsync\_path        |`rsync` コマンドの `--rsync-path` オプション。                                                  |No  |`'/usr/bin/rsync'`                                   |
 rsh                |`rsync` コマンドの `--rsh` オプション。                                                         |No  |`'/usr/bin/rsync'`                                   |

--- a/README.md
+++ b/README.md
@@ -118,15 +118,16 @@ return array(
 
 ### 各設定値の詳細
 
-項目名           |説明                                                                                            |必須|設定例                                               |
------------------|------------------------------------------------------------------------------------------------|----|-----------------------------------------------------|
-destinations     |シンク先サーバのホスト名を配列で指定する。                                                      |Yes |`array('server1.example.net', 'server2.example.net')`|
-ssh\_user        |対象ホストへの接続に使用する SSH ユーザ名。                                                     |No  |`'testuser'`                                         |
-exclude\_from    |`rsync` コマンドの `--exclude-from` オプション。除外ファイルの一覧を記述したファイルを指定する。|No  |`dirname(__FILE__) . '/rsync_exclude'`               |
-rsync\_path      |`rsync` コマンドの `--rsync-path` オプション。                                                  |No  |`'/usr/bin/rsync'`                                   |
-rsh              |`rsync` コマンドの `--rsh` オプション。                                                         |No  |`'/usr/bin/rsync'`                                   |
-default\_checksum|`true` にすると `rsync` コマンドに `--checksum` オプションが付加される。デフォルトは `false`。  |No  |`true`                                               |
-log\_directory   |ログファイルを保存するディレクトリのパス。でフォルトは `.phync/log`                             |No  |`'/path/to/log-directory'`                           |
+項目名             |説明                                                                                            |必須|設定例                                               |
+-------------------|------------------------------------------------------------------------------------------------|----|-----------------------------------------------------|
+destinations       |シンク先サーバのホスト名を配列で指定する。                                                      |Yes |`array('server1.example.net', 'server2.example.net')`|
+ssh\_user          |対象ホストへの接続に使用する SSH ユーザ名。                                                     |No  |`'testuser'`                                         |
+remote\_target\_dir|リモートの対象ディレクトリへのパス。                                                            |No  |`'/path/to/target-directory'`                        |
+exclude\_from      |`rsync` コマンドの `--exclude-from` オプション。除外ファイルの一覧を記述したファイルを指定する。|No  |`dirname(__FILE__) . '/rsync_exclude'`               |
+rsync\_path        |`rsync` コマンドの `--rsync-path` オプション。                                                  |No  |`'/usr/bin/rsync'`                                   |
+rsh                |`rsync` コマンドの `--rsh` オプション。                                                         |No  |`'/usr/bin/rsync'`                                   |
+default\_checksum  |`true` にすると `rsync` コマンドに `--checksum` オプションが付加される。デフォルトは `false`。  |No  |`true`                                               |
+log\_directory     |ログファイルを保存するディレクトリのパス。でフォルトは `.phync/log`                             |No  |`'/path/to/log-directory'`                           |
 
 ### 設定ファイルパスの指定
 

--- a/src/Phync/Config.php
+++ b/src/Phync/Config.php
@@ -88,4 +88,12 @@ class Phync_Config
             $this->config['ssh_user'] :
             NULL;
     }
+
+    public function getRemoteTargetDir()
+    {
+        return array_key_exists('remote_target_dir', $this->config) &&
+            (string)$this->config['remote_target_dir'] !== '' ?
+            $this->config['remote_target_dir'] :
+            NULL;
+    }
 }

--- a/tests/Phync/Tests/CommandGeneratorTest.php
+++ b/tests/Phync/Tests/CommandGeneratorTest.php
@@ -223,6 +223,20 @@ class Phync_Tests_CommandGeneratorTest extends Phync_Tests_TestCase
     /**
      * @test
      */
+    public function コマンドライン引数が無くてリモートの対象ディレクトリが指定されているとき()
+    {
+        $option    = $this->createOption();
+        $config    = $this->createConfigWithRemoteTargetDir('/target-dir');
+        $generator = new Phync_CommandGenerator($config, $this->createMockFileUtil());
+        $this->assertEquals(
+            array("rsync -av --dry-run --delete '/working-dir/' 'localhost:/target-dir/'"),
+            $generator->getCommands($option)
+        );
+    }
+
+    /**
+     * @test
+     */
     public function checksumオプションがあればチェックサムを行う()
     {
         $option = $this->createOption('--checksum');
@@ -368,6 +382,20 @@ class Phync_Tests_CommandGeneratorTest extends Phync_Tests_TestCase
             'destinations' => array('localhost')
         ));
         Phake::when($config)->getSshUserName()->thenReturn($sshUserName);
+        return $config;
+    }
+
+    /**
+     * リモートの対象ディレクトリの設定を持つ Phync_Config オブジェクトを生成する
+     *
+     * @return Phync_Config
+     */
+    private function createConfigWithRemoteTargetDir($remoteTargetDir)
+    {
+        $config = Phake::partialMock('Phync_Config', array(
+            'destinations' => array('localhost')
+        ));
+        Phake::when($config)->getRemoteTargetDir()->thenReturn($remoteTargetDir);
         return $config;
     }
 }

--- a/tests/Phync/Tests/CommandGeneratorTest.php
+++ b/tests/Phync/Tests/CommandGeneratorTest.php
@@ -236,6 +236,108 @@ class Phync_Tests_CommandGeneratorTest extends Phync_Tests_TestCase
 
     /**
      * @test
+     * @dataProvider provideCwd
+     */
+    public function コマンドライン引数がカレントディレクトリでリモート対象ディレクトリが指定されているとき($cwd)
+    {
+        $option    = $this->createOption();
+        $config    = $this->createConfigWithRemoteTargetDir('/target-dir');
+        $generator = new Phync_CommandGenerator($config, $this->createMockFileUtil());
+        $this->assertEquals(
+            array("rsync -av --dry-run --delete '/working-dir/' 'localhost:/target-dir/'"),
+            $generator->getCommands($option)
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider provideFilePath
+     */
+    public function リモート対象ディレクトリが指定されていて特定のファイルだけをアップするとき($file)
+    {
+        $option    = $this->createOption($file);
+        $config    = $this->createConfigWithRemoteTargetDir('/target-dir');
+        $generator = new Phync_CommandGenerator($config, $this->createMockFileUtil());
+        $this->assertEquals(
+            array("rsync -av --dry-run --delete '/working-dir/' 'localhost:/target-dir/' --include '/file' --exclude '*'"),
+            $generator->getCommands($option)
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider provideDirPath
+     */
+    public function リモート対象ディレクトリが指定されていて特定のディレクトリ全体をアップするとき($dir)
+    {
+        $option    = $this->createOption($dir);
+        $config    = $this->createConfigWithRemoteTargetDir('/target-dir');
+        $generator = new Phync_CommandGenerator($config, $this->createMockFileUtil());
+        $this->assertEquals(
+            array("rsync -av --dry-run --delete '/working-dir/' 'localhost:/target-dir/' --include '/dir/' --include '/dir/*' --include '/dir/**/*' --exclude '*'"),
+            $generator->getCommands($option)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function リモート対象ディレクトリが指定されていて深い階層のファイルを指定するとき()
+    {
+        $option    = $this->createOption('dir/file');
+        $config    = $this->createConfigWithRemoteTargetDir('/target-dir');
+        $generator = new Phync_CommandGenerator($config, $this->createMockFileUtil());
+        $this->assertEquals(
+            array("rsync -av --dry-run --delete '/working-dir/' 'localhost:/target-dir/' --include '/dir/file' --include '/dir/' --exclude '*'"),
+            $generator->getCommands($option)
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider provideDeepDirPath
+     */
+    public function リモート対象ディレクトリが指定されていて深い階層のディレクトリを指定するとき($dir, $command)
+    {
+        $option    = $this->createOption($dir);
+        $config    = $this->createConfigWithRemoteTargetDir('/target-dir');
+        $generator = new Phync_CommandGenerator($config, $this->createMockFileUtil());
+        $this->assertEquals(
+            array("rsync -av --dry-run --delete '/working-dir/' 'localhost:/target-dir/' {$command} --exclude '*'"),
+            $generator->getCommands($option)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function リモート対象ディレクトリが指定されていて複数のファイルが指定されているとき()
+    {
+        $option    = $this->createOption('file', 'another_file');
+        $config    = $this->createConfigWithRemoteTargetDir('/target-dir');
+        $generator = new Phync_CommandGenerator($config, $this->createMockFileUtil());
+        $this->assertEquals(
+            array("rsync -av --dry-run --delete '/working-dir/' 'localhost:/target-dir/' --include '/file' --include '/another_file' --exclude '*'"),
+            $generator->getCommands($option)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function リモート対象ディレクトリが指定されていてファイルとディレクトリが混ざっているとき()
+    {
+        $option    = $this->createOption('file', 'another_file', 'dir');
+        $config    = $this->createConfigWithRemoteTargetDir('/target-dir');
+        $generator = new Phync_CommandGenerator($config, $this->createMockFileUtil());
+        $this->assertEquals(
+            array("rsync -av --dry-run --delete '/working-dir/' 'localhost:/target-dir/' --include '/file' --include '/another_file' --include '/dir/' --include '/dir/*' --include '/dir/**/*' --exclude '*'"),
+            $generator->getCommands($option)
+        );
+    }
+
+    /**
+     * @test
      */
     public function checksumオプションがあればチェックサムを行う()
     {

--- a/tests/Phync/Tests/ConfigTest.php
+++ b/tests/Phync/Tests/ConfigTest.php
@@ -65,4 +65,23 @@ class Phync_Tests_ConfigTest extends Phync_Tests_TestCase
         $config = new Phync_Config($this->defaultConfigValues);
         $this->assertEquals('testuser', $config->getSshUserName());
     }
+
+    /**
+     * @test
+     */
+    public function getRemoteTargetDir_デフォルトはnull()
+    {
+        $config = new Phync_Config($this->defaultConfigValues);
+        $this->assertNull($config->getRemoteTargetDir());
+    }
+
+    /**
+     * @test
+     */
+    public function getRemoteTargetDir_remote_target_dirが指定されているとき()
+    {
+        $this->defaultConfigValues['remote_target_dir'] = '/specific_target_dir';
+        $config = new Phync_Config($this->defaultConfigValues);
+        $this->assertEquals('/specific_target_dir', $config->getRemoteTargetDir());
+    }
 }


### PR DESCRIPTION
By default, Phync uploads files into same path on remote hosts.
If path of local and remote has difference, this config is convenient.
